### PR TITLE
Better config screen title

### DIFF
--- a/omega-config-gui/build.gradle
+++ b/omega-config-gui/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     modCompileOnly ("com.terraformersmc:modmenu:${project.modmenu_version}") {
         transitive(false)
     }
-    modRuntime ("com.terraformersmc:modmenu:${project.modmenu_version}") {
+    modRuntimeOnly ("com.terraformersmc:modmenu:${project.modmenu_version}") {
         transitive(false)
     }
 

--- a/omega-config-gui/src/main/java/draylar/omegaconfiggui/OmegaConfigGui.java
+++ b/omega-config-gui/src/main/java/draylar/omegaconfiggui/OmegaConfigGui.java
@@ -10,6 +10,7 @@ import net.fabricmc.api.Environment;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.LiteralText;
+import net.minecraft.text.TranslatableText;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
@@ -55,7 +56,7 @@ public class OmegaConfigGui {
         return parent -> {
             try {
                 Config defaultConfig = config.getClass().getDeclaredConstructor().newInstance();
-                ConfigScreen screen = ConfigScreen.create(new LiteralText(config.getName()), parent);
+                ConfigScreen screen = ConfigScreen.create(new TranslatableText(String.format("config.%s.%s", config.getModid(), config.getName())), parent);
 
                 // Fields
                 for (Field field : config.getClass().getDeclaredFields()) {

--- a/src/testmod/resources/assets/omegatest/lang/en_us.json
+++ b/src/testmod/resources/assets/omegatest/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "config.omega-config-test.test-config": "Omega Config - Test Config"
+}


### PR DESCRIPTION
OmegaConfigGui's config screen currently uses a `LiteralText` as its title; this pull request changes it to use a `TranslatableText` (key is set as `config.modid.configname`) instead, allowing modders to have a fancier, language specific title for the Config Screen. The testmod is also updated to test this change.
